### PR TITLE
Support for project folder in dbt uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,11 @@ Follow the steps below to set up the integration:
 
 - Separately, you will have received a Revefi Auth token; keep that in a secure place (like your password manager)
 
-- In a terminal, run the command `python3 -m revefi-dbt-client.upload dbt --token <auth-token> --target_folder <target-folder>`, where `<auth-token>` is the token you received in Step b) above and `<target-folder>` is 
-the Target folder you used for your dbt run
+- In a terminal, run the command `python3 -m revefi-dbt-client.upload dbt --token <auth-token> --project_folder <project-folder>`, where `<auth-token>` is the token you received in Step b) above and `<project-folder>` is 
+the Project folder you have created for the dbt.
+
+## Note
+
+The uploader assumes that the dbt target path is set to "target" within the project folder. If you are using some other target path, you may override the default behavior with
+
+`python3 -m revefi-dbt-client.upload dbt --token <auth-token> --project_folder <project-folder> --target_folder <target-folder>`

--- a/revefi-dbt-client/upload.py
+++ b/revefi-dbt-client/upload.py
@@ -76,6 +76,11 @@ class RevefiCli:
         project_folder_path = Path(self.project_folder)
         target_folder_path = None
 
+        # check "dbt_project.yml" file is present in the project folder
+        self.project_file_path = Path(os.path.join(project_folder_path, DBT_PROJECT_FILE_NAME))
+        if not self.project_file_path.exists():
+            error(f"Unable to locate '{DBT_PROJECT_FILE_NAME}' in the path - '{project_folder_path}'")
+
         if not self.target_folder:
             # default to "target" within the project folder
             self.target_folder = Path(os.path.join(project_folder_path, DBT_DEFAULT_TARGET_FOLDER_NAME))
@@ -83,12 +88,6 @@ class RevefiCli:
         target_folder_path = Path(self.target_folder)
         if not target_folder_path.is_dir():
             error(f"Invalid target folder: {self.target_folder}")
-    
-        # check "dbt_project.yml" file is present in the project folder
-        self.project_file_path = Path(os.path.join(project_folder_path, DBT_PROJECT_FILE_NAME))
-        if not self.project_file_path.exists():
-            raise RuntimeError(
-                f"Unable to locate '{DBT_PROJECT_FILE_NAME}' in the path - '{project_folder_path}'")
 
         # check that either manifest.json or run_results.json is present
         self.manifest_path = Path(os.path.join(target_folder_path, "manifest.json"))

--- a/revefi-dbt-client/upload.py
+++ b/revefi-dbt-client/upload.py
@@ -88,7 +88,7 @@ class RevefiCli:
         self.project_file_path = Path(os.path.join(project_folder_path, DBT_PROJECT_FILE_NAME))
         if not self.project_file_path.exists():
             raise RuntimeError(
-                f"Unable to locate 'project.yaml' in the path - '{project_folder_path}'")
+                f"Unable to locate '{DBT_PROJECT_FILE_NAME}' in the path - '{project_folder_path}'")
 
         # check that either manifest.json or run_results.json is present
         self.manifest_path = Path(os.path.join(target_folder_path, "manifest.json"))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name='revefi-dbt-client',
-    version='0.0.1',
+    version='0.0.2',
     author='Revefi Team',
     description='Package to upload dbt core files to Revefi',
     long_description=long_description,


### PR DESCRIPTION
## Description

The uploader now uses "dbt_project.yml" from the dbt project folder instead of creating its own.

## Test

1. Verified that correct file was picked in the zip file. Verified the contents of the zip manually.
2. Verified with "project_folder" argument
3. Verified with "project_folder and target_folder" argument.

Edge cases
1. project_folder argument is not supplied
```
Usage: upload.py dbt [-h] --token TOKEN --project_folder PROJECT_FOLDER [--target_folder TARGET_FOLDER] [--logs_folder LOGS_FOLDER] [--endpoint ENDPOINT]
upload.py dbt: error: the following arguments are required: --project_folder
```

2. invalid project_folder name is supplied 
```
[ERROR] Invalid target folder: /Users/kaushik/revefi/dbt_test/2/target
Traceback (most recent call last):
  File "/Users/kaushik/revefi/dbt_python_client/revefi-dbt-client/upload.py", line 165, in <module>
    main()
  File "/Users/kaushik/revefi/dbt_python_client/revefi-dbt-client/upload.py", line 160, in main
    deployer.is_valid()
  File "/Users/kaushik/revefi/dbt_python_client/revefi-dbt-client/upload.py", line 90, in is_valid
    raise RuntimeError(
RuntimeError: Unable to locate 'dbt_project.yml' in the path - '/Users/kaushik/revefi/dbt_test/2'
```