### PR TITLE
Remove unwanted chunking of data

### DIFF
--- a/src/revefi_dbt_client/api_helper.py
+++ b/src/revefi_dbt_client/api_helper.py
@@ -4,8 +4,6 @@ import logging
 
 import requests
 
-from revefi_dbt_client.config import Config
-
 
 class MakeApiCall:
     log = logging.getLogger(__name__)
@@ -21,21 +19,14 @@ class MakeApiCall:
         if len(contents) > 64 * 1024 * 1024:
             self.log.error("File size exceeds 64 MB. Please try again with a smaller file size.")
             return
-
         response = requests.post(f"{api}",
-                                 data={'token': token, 'hash': hash, 'contents': self.chunk_data(encoded_string)})
+                                 json={'token': token, 'hash': hash, 'contents': [encoded_string]})
 
         if response.status_code == 200:
             self.log.info("Upload successful.")
         else:
             self.log.error(f"[{response.status_code}] Unable to upload - {response}")
             return
-
-    def chunk_data(self, contents):
-        chunk_size = Config.get_chunk_size()
-        total_size = len(contents)
-        chunks = [contents[i:i + chunk_size] for i in range(0, total_size, chunk_size)]
-        yield from chunks
 
     def __init__(self, api, token, contents):
         self.get_data(api, token, contents)

--- a/src/revefi_dbt_client/config.py
+++ b/src/revefi_dbt_client/config.py
@@ -6,7 +6,6 @@ _CONFIG = Dynaconf(
 )
 
 _API_ENDPOINT = "https://gateway.revefi.com/api/uploadFile"
-_CHUNK_SIZE = 524288  # 0.5MB chunk size
 
 
 class Config:
@@ -14,10 +13,6 @@ class Config:
     @staticmethod
     def get_api_endpoint() -> str:
         return _CONFIG.get('API_ENDPOINT', _API_ENDPOINT)
-
-    @staticmethod
-    def get_chunk_size() -> int:
-        return _CONFIG.get('CHUNK_SIZE', _CHUNK_SIZE)
 
     @staticmethod
     def get_log_level() -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,3 @@ from revefi_dbt_client.config import Config
 
 def test_get_api_endpoint():
     assert Config.get_api_endpoint() == "https://gateway.revefi.com/api/uploadFile"
-
-
-def test_get_chunk_size():
-    assert Config.get_chunk_size() == 524288


### PR DESCRIPTION
This PR introduces the following changes:

- In its current state, the `encoded_string` is chunked and then sent in the form-data of post request. This is unnecessary since all the chunks are sent in a single request. This PR removes the unnecessary chunking.
- The server expects the data to be in JSON format, however, this client sends the data as form data. This PR introduces changes to send it in JSON format.

These changes were tested by using the client to upload files against the dev environment.
```shell
$ REVEFI_API_ENDPOINT="https://dev-gateway.revefi.com/api/uploadFile" revefi-dbt-client dbt --token <token> --project_folder "/Users/sumeet/revefi/dbt/dbt-core-sample-data/Orders_100_030923_BigQuery/Oct-08-2023"

[18925] 2023-10-12 10:40:43,553 [INFO] revefi_dbt_client.api_helper: Upload successful.
```

Note: None of the above changes shall break existing client-server contracts.