### PR TITLE
Remove DBT subparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ models [e.g. model code changes].
 
 - Once installed, run the following command in the terminal
   ```shell
-  revefi-dbt-client dbt --token <auth-token> --project_folder <project-folder>
+  revefi-dbt-client --token <auth-token> --project_folder <project-folder>
   ```
   where 
   - `<auth-token>` is the token you received in Step b) above

--- a/src/revefi-dbt-client/upload.py
+++ b/src/revefi-dbt-client/upload.py
@@ -12,4 +12,4 @@ Once all the customers migrate to the new package name, this module can be remov
 """
 
 if __name__ == "__main__":
-    main()
+    main(legacy_parser=True)

--- a/src/revefi_dbt_client/__init__.py
+++ b/src/revefi_dbt_client/__init__.py
@@ -1,1 +1,6 @@
 __version__ = '0.1.1'
+
+from revefi_dbt_client.config import Config
+from revefi_dbt_client.logging import configure_logging
+
+configure_logging(Config.get_log_level())

--- a/src/revefi_dbt_client/main.py
+++ b/src/revefi_dbt_client/main.py
@@ -1,16 +1,25 @@
+import logging
 import sys
+import textwrap
 
-from revefi_dbt_client.config import Config
-from revefi_dbt_client.logging import configure_logging
-from revefi_dbt_client.parser import parse_args
+from revefi_dbt_client.parser import parse_args_legacy, parse_args_v2
 from revefi_dbt_client.upload import upload
 
+LOG = logging.getLogger(__name__)
 
-def main():
+
+def main(legacy_parser=False):
     argv = sys.argv[1:]
-    configure_logging(Config.get_log_level())
-    args = parse_args(argv)
-    upload(args.token, args.project_folder, args.target_folder, args.logs_folder, args.endpoint)
+
+    if legacy_parser:
+        LOG.warning(textwrap.dedent("""
+                                       Using legacy parser,
+                                       please update how CLI is invoked as per the documentation: https://github.com/revefi/dbt_python_client"""))
+        args = parse_args_legacy(argv)
+    else:
+        args = parse_args_v2(argv)
+
+    upload(args.token, args.project_folder, args.target_folder, args.logs_folder)
 
 
 if __name__ == "__main__":

--- a/src/revefi_dbt_client/parser.py
+++ b/src/revefi_dbt_client/parser.py
@@ -1,14 +1,24 @@
 import argparse
 
 
-def parse_args(argv):
+def _add_parser_args(parser: argparse.ArgumentParser):
+    parser.add_argument("--token", required=True, type=str, help="validation token")
+    parser.add_argument("--project_folder", required=True, type=str, help="dbt project folder")
+    parser.add_argument("--target_folder", required=False, type=str, help="target folder for the dbt run")
+    parser.add_argument("--logs_folder", required=False, type=str, help="log folder from the dbt run")
+
+
+def parse_args_legacy(argv):
     parser = argparse.ArgumentParser(description="revefi dbt cli")
     subparsers = parser.add_subparsers(dest='command')
     dbt_parser = subparsers.add_parser('dbt')
-    dbt_parser.add_argument("--token", required=True, type=str, help="validation token")
-    dbt_parser.add_argument("--project_folder", required=True, type=str, help="dbt project folder")
-    dbt_parser.add_argument("--target_folder", required=False, type=str, help="target folder for the dbt run")
-    dbt_parser.add_argument("--logs_folder", required=False, type=str, help="log folder from the dbt run")
-    dbt_parser.add_argument("--endpoint", required=False, type=str, help="endpoint for API")
+    _add_parser_args(dbt_parser)
+    args = parser.parse_args(argv)
+    return args
+
+
+def parse_args_v2(argv):
+    parser = argparse.ArgumentParser(description="revefi dbt cli")
+    _add_parser_args(parser)
     args = parser.parse_args(argv)
     return args

--- a/src/revefi_dbt_client/upload.py
+++ b/src/revefi_dbt_client/upload.py
@@ -12,12 +12,11 @@ _DBT_DEFAULT_TARGET_FOLDER_NAME = "target"
 
 
 class Uploader:
-    def __init__(self, token, project_folder, target_folder, logs_folder, endpoint):
+    def __init__(self, token, project_folder, target_folder, logs_folder):
         self.token = token
         self.project_folder = project_folder
         self.target_folder = target_folder
         self.logs_folder = logs_folder
-        self.endpoint = endpoint
         self.project_file_path = None
         self.manifest_path = None
         self.run_results_path = None
@@ -112,5 +111,5 @@ class Uploader:
         return zip_file_path
 
 
-def upload(token, project_folder, target_folder=None, logs_folder=None, endpoint=None):
-    Uploader(token, project_folder, target_folder, logs_folder, endpoint).upload()
+def upload(token, project_folder, target_folder=None, logs_folder=None):
+    Uploader(token, project_folder, target_folder, logs_folder).upload()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,22 @@
+import sys
+
+import pytest
+
+from revefi_dbt_client.main import main
+
+
+@pytest.fixture(scope='function')
+def mock_upload(monkeypatch):
+    monkeypatch.setattr('revefi_dbt_client.main.upload', lambda *args, **kwargs: None)
+
+
+def test_main_with_legacy_parser(mock_upload, monkeypatch):
+    argv = 'revefi-dbt-client dbt --token definitely-a-real-token --project_folder /path/to/project/dir'.split(' ')
+    monkeypatch.setattr(target=sys, name='argv', value=argv)
+    main(legacy_parser=True)
+
+
+def test_main_with_v2_parser(mock_upload, monkeypatch):
+    argv = 'revefi-dbt-client --token definitely-a-real-token --project_folder /path/to/project/dir'.split(' ')
+    monkeypatch.setattr(target=sys, name='argv', value=argv)
+    main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,35 @@
+from revefi_dbt_client.parser import parse_args_legacy, parse_args_v2
+
+
+def test_parse_args_legacy():
+    argv = 'dbt --token definitely-a-real-token --project_folder /path/to/project/dir'.split(' ')
+    args = parse_args_legacy(argv)
+    assert args.token == 'definitely-a-real-token'
+    assert args.project_folder == '/path/to/project/dir'
+    assert args.target_folder is None
+    assert args.logs_folder is None
+
+    argv = 'dbt --token definitely-a-real-token --project_folder /path/to/project/dir --target_folder custom_target_dir --logs_folder /path/to/logs/dir'.split(
+        ' ')
+    args = parse_args_legacy(argv)
+    assert args.token == 'definitely-a-real-token'
+    assert args.project_folder == '/path/to/project/dir'
+    assert args.target_folder == 'custom_target_dir'
+    assert args.logs_folder == '/path/to/logs/dir'
+
+
+def test_parse_args_v2():
+    argv = '--token definitely-a-real-token --project_folder /path/to/project/dir'.split(' ')
+    args = parse_args_v2(argv)
+    assert args.token == 'definitely-a-real-token'
+    assert args.project_folder == '/path/to/project/dir'
+    assert args.target_folder is None
+    assert args.logs_folder is None
+
+    argv = '--token definitely-a-real-token --project_folder /path/to/project/dir --target_folder custom_target_dir --logs_folder /path/to/logs/dir'.split(
+        ' ')
+    args = parse_args_v2(argv)
+    assert args.token == 'definitely-a-real-token'
+    assert args.project_folder == '/path/to/project/dir'
+    assert args.target_folder == 'custom_target_dir'
+    assert args.logs_folder == '/path/to/logs/dir'


### PR DESCRIPTION
This PR removes the DBT sub-parser from the arg parser.

However, the legacy way of passing arguments is still allowed with a warning for backward compatibility.